### PR TITLE
improve: use `const T` to infer array values without const assertion

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ new Command({
   description: "Change a player's gamemode",
   aliases: ["gm"],
 })
-  .array("mode", ["survival", "creative", "adventure", "spectator"] as const)
+  .array("mode", ["survival", "creative", "adventure", "spectator"])
   .executes((ctx, mode) => {
     // Change gamemode implementation
   })

--- a/src/models/ArgumentTypes.ts
+++ b/src/models/ArgumentTypes.ts
@@ -203,7 +203,7 @@ export class TargetArgumentType implements IArgumentType {
   }
 }
 
-export class ArrayArgumentType<T extends ReadonlyArray<string>>
+export class ArrayArgumentType<const T extends Array<string>>
   implements IArgumentType
 {
   type!: T[number];

--- a/src/models/Command.ts
+++ b/src/models/Command.ts
@@ -97,7 +97,7 @@ export class Command<Callback extends Function = DefaultCommandCallback> {
    * @param name name this argument should have
    * @returns new branch to this command
    */
-  array<T extends ReadonlyArray<string>>(
+  array<const T extends Array<string>>(
     name: string,
     types: T
   ): ArgReturn<Callback, T[number]> {


### PR DESCRIPTION
You can use `.array()` without using `as const` by using const type parameter

![image](https://github.com/user-attachments/assets/9b4ca2c3-fa2d-447c-a6e4-0d90569ae862)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Updated internal type constraints for array arguments to improve type handling. No changes to user-facing features or functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->